### PR TITLE
bump oom-demo memory to 228Mi

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,10 +37,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 178Mi
+              memory: 228Mi
             requests:
               cpu: 100m
-              memory: 178Mi
+              memory: 228Mi
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
Increase oom-demo container memory limits and requests from 178Mi to 228Mi, providing extra overhead to avoid future OOMKilled events and practice robust resource configuration. This is submitted via pull request as per process best practice (no direct commits to main).

- File updated: oom-demo/manifest.yaml
- Context: Incident remediation and user request to refactor fix into PR flow.