### PR TITLE
Increase oom-demo memory limit to 178Mi for stability

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
This PR increases the memory limit of the oom-demo deployment to 178Mi, following an OOMKilled incident in production. Raising the limit has stabilized the pod and resolved the CrashLoopBackOff event.