### PR TITLE
Enable auto sync for guestbook-prod-oom application

### DIFF
--- a/akp-demo/bootstrap/argocd/01-argocd-apps.yaml
+++ b/akp-demo/bootstrap/argocd/01-argocd-apps.yaml
@@ -90,6 +90,7 @@ spec:
     name: demo
     namespace: akp-demo
   syncPolicy:
+    automated: {}
     syncOptions:
     - CreateNamespace=true
 


### PR DESCRIPTION
Update guestbook-prod-oom Application YAML to enable Argo CD auto sync (`automated: {}` in syncPolicy). This allows automatic reconciliation with Git.