### PR TITLE
Disable auto sync for bootstrap app

### DIFF
--- a/akp-demo/bootstrap/argocd/02-kargo-bootstrap.yaml
+++ b/akp-demo/bootstrap/argocd/02-kargo-bootstrap.yaml
@@ -14,5 +14,4 @@ spec:
   destination:
     name: kargo
   syncPolicy:
-    automated:
-      prune: true
+    # automated: removed to disable auto sync


### PR DESCRIPTION
This PR removes the `automated` section from the syncPolicy of the akp-demo-bootstrap-kargo application, disabling auto sync as requested.