### PR TITLE
fix: bump oom-demo memory to 178Mi (Resolves OOMKilled incident)

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
Increase memory limit for oom-demo from 128Mi to 178Mi to resolve OOMKilled/crashloop incident. This change aligns pod resources with workload demand and stabilizes deployment. Please review for merge.