### PR TITLE
fix: increase memory limit for oom-demo to 178Mi for stability

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
Incident summary: The guestbook-prod-oom deployment experienced repeated pod OOMKilled events due to insufficient memory limits (128Mi vs 150Mi requested at runtime). We increased the memory limit to 178Mi directly in-cluster and validated that pods are now stable. This PR persists that fix in version control for future deployments.

- Root cause: memory limit too low for stress container workload
- Solution: memory limit increased to 178Mi per incident runbook
- Context: See Argo CD Application guestbook-prod-oom and the associated Slack thread for details and timeline

Please review and merge after validation. DO NOT SQUASH.