### PR TITLE
fix(infra): increase memory limit for oom-demo to prevent OOMKilled

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
### Summary
This PR increases the memory limit for the oom-demo deployment to 178Mi to prevent OOMKilled events under the current workload.

- Incident: Pod was crash looping due to memory limit being set below workload (stress --vm-bytes 150M vs limit 128Mi).
- Solution: Increased the memory limit to 178Mi.
- Reference: [Argo conversation link](https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=wnvhg08na1mtfdjy)
- Slack thread: see jiacheng-aki-demo channel

Please review and merge to make this fix permanent.
