### PR TITLE
fix: increase memory limit for oom-demo from 128Mi to 178Mi

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 178Mi
+              memory: 192Mi
             requests:
               cpu: 100m
               memory: 128Mi

--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
This PR increases the memory limit for the `oom-demo` deployment from 128Mi to 178Mi to address repeated OOMKilled pod events and associated degraded application status. Incident and triage were traced in Argo CD and Slack. For further context, see incident discussion: https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=7hv2ljcjj66pl3xu

- Symptom: Pod repeatedly OOMKilled
- Root cause: Insufficient memory limit
- Solution: Increment memory limit by 50Mi

Slack thread for ongoing triage: https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=7hv2ljcjj66pl3xu