### PR TITLE
fix: increase memory limit for oom-demo deployment to 178Mi

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
### Incident Summary

This PR increases the memory limit for the `oom-demo` deployment from 128Mi to 178Mi in response to a production OOMKilled event. Pods were repeatedly killed after exceeding their 128Mi memory limit. After raising the limit by 50Mi, the deployment stabilized immediately.

#### Details
- Incident detected in Argo CD application: guestbook-prod-oom
- CrashLoopBackOff and OOMKilled were observed in pod.
- Post-increase, pods converged and deployment marked Healthy.
- Incident and fix documented in Slack thread and in Akuity chat: https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=vrhjhr93qous9i0i

Please review and merge to keep Git in sync with running cluster.
