### PR TITLE
fix: increase memory limit for oom-demo to mitigate OOMKilled crash

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
### Incident Summary
- The 'guestbook-prod-oom' application's 'oom-demo' deployment experienced repeated OOMKilled pod crashes, leading to a degraded state.
- Root cause: container memory overuse beyond its previous 128Mi limit, causing deployment failure.
- This PR increases the memory limit to 178Mi to stabilize the deployment.

### What was changed?
- Modified `oom-demo/manifest.yaml`: Increased memory limit from `128Mi` to `178Mi` for the problematic container.

### Why?
- To resolve production OOM incidents and ensure stability following the live patch.

### References
- [Incident troubleshooting conversation](https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=q2mhrtl2bdh3egk7)
- Slack thread: see channel `#jiacheng-aki-demo` for real-time updates.

---
Please review and merge to permanently resolve the incident.
