### PR TITLE
fix: increase memory limit for oom-demo after OOM incident

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,10 +37,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
## Incident summary
This PR increases the memory requests and limits for the `oom-demo` container from 128Mi to 178Mi to remediate repeated OOMKilled/crash looping. Resolution follows the playbook for out-of-memory incidents.

### Context
- Link to Slack thread: https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=x1vfm7a7v1l1wiqp
- Automated follow-up confirmed no further OOM errors after limit increase

### What changed
- Increased memory limits & requests for the `oom` container in `oom-demo/manifest.yaml`

### Why
- Pods previously OOMKilled and degraded. Fixed with higher memory setting after triage & validation.

---
PR is based on latest `main`. Please review and merge to complete the incident remediation.
