### PR TITLE
fix: increase memory limit for oom-demo deployment to 178Mi

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
Incident: guestbook-prod-oom experienced OOMKilled events due to memory limit exceeded (128Mi) on pod 'oom-demo'. This PR increases the container memory limit to 178Mi to stabilize the deployment.

Incident tracking and root cause in Slack and incident system:
- Slack: #jiacheng-aki-demo
- Incident Conversation: https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=higc6ygv1mlyp56z

This change addresses the immediate OOM issue; further observation recommended.