### PR TITLE
fix: increase memory limit for oom pod (guestbook-prod-oom) to 178Mi

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,10 +37,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
### Incident summary
This PR increases the memory limit for the 'oom' container in the guestbook-prod-oom Deployment from 128Mi to 178Mi to resolve a recent OOMKilled/CrashLoopBackOff incident in the akp-demo namespace. 

#### What happened?
- Pods were consistently OOMKilled due to the workload using more memory than the limits.
- Temporary fix was applied by patching the deployment in Kubernetes, which has now restored stability.

#### Change
- Sets memory `requests` and `limits` for the 'oom' container to `178Mi` in `oom-demo/manifest.yaml`.

#### Why?
- Resolves repeated OOM errors and incident outages for this environment.
- Full context: [see incident thread and conversation].

---

Please review and merge to make this fix permanent.