### PR TITLE
fix: increase memory limit for oom-demo deployment to 178Mi

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
Increase memory limit for the oom-demo deployment from 128Mi to 178Mi to prevent OOMKilled pod restarts. Incident root cause: application container required more memory than provisioned. See the Akuity incident and Slack thread for the full remediation workflow.

- OOMKilled occurred with original 128Mi limit
- Temporary patch of 178Mi restored stability
- This PR makes the fix permanent

References:
- [Akuity incident link](https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=hx9iqklcjeouvns1)
- Slack channel: #jiacheng-aki-demo