### PR TITLE
fix: increase memory limit for oom-demo deployment to 178Mi

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 178Mi
             requests:
               cpu: 100m
               memory: 128Mi


### PR DESCRIPTION
## Incident Summary
Deployment 'oom-demo' in guestbook-prod-oom experienced repeated OOMKilled events.

### Root Cause
Original memory limit (128Mi) was insufficient causing the pod to fail with OOMKilled. This caused the deployment to be degraded.

### Resolution
Memory limit increased to 178Mi in oom-demo/manifest.yaml. This change addresses the OOM events and restores application stability.

### References
- Incident discussion & debug: https://z27h8amokc3shn8l.cd.akuity.cloud/applications/argocd/guestbook-prod-oom?akuity-chat=0dv8mukvtjffok38
- Initial fix and monitoring confirmed recovery.

