### PR TITLE
Restore memory limit for oom-demo to 192Mi (GitOps match live hotfix)

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 89Mi
+              memory: 192Mi
             requests:
               cpu: 100m
               memory: 64Mi


### PR DESCRIPTION
This PR restores the memory limit for the 'oom-demo' Deployment to 192Mi, matching the live cluster hotfix after OOMKilled rollout failures. This aligns source-of-truth to stop future OOMKills due to insufficient memory. Resolves incident and ensures continued Deployment health.

- Raised resources.limits.memory from 89Mi to 192Mi in oom-demo/manifest.yaml
- Aligns manifests repo with current working state in production

Please review and merge to ensure GitOps consistency going forward.