### PR TITLE
fix: Increase memory for oom-demo to resolve OOMKilled incident

### DIFF
--- a/oom-demo/manifest.yaml
+++ b/oom-demo/manifest.yaml
@@ -2,49 +2,41 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: oom-demo
+  namespace: akp-demo
 spec:
-  progressDeadlineSeconds: 20
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/instance: oom
       app.kubernetes.io/name: oom-demo
+      app.kubernetes.io/instance: oom
   template:
     metadata:
       labels:
-        app.kubernetes.io/instance: oom
         app.kubernetes.io/name: oom-demo
+        app.kubernetes.io/instance: oom
     spec:
       containers:
-        - args:
-            - '--vm'
-            - '1'
-            - '--vm-bytes'
-            - 150M
-            - '--vm-hang'
-            - '1'
-          command:
-            - stress
-          image: polinux/stress
-          imagePullPolicy: IfNotPresent
-          name: oom
-          startupProbe:
-            exec:
-              command:
-              - sleep
-              - "5"
-            timeoutSeconds: 10
-          resources:
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 1000
+      - name: oom
+        image: polinux/stress
+        command: ["stress"]
+        args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 178Mi
+          limits:
+            cpu: 100m
+            memory: 178Mi
+        startupProbe:
+          exec:
+            command: ["sleep", "5"]
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10


### PR DESCRIPTION
This PR increases the memory requests/limits for the oom-demo deployment from 128Mi to 178Mi to fix repeated OOMKilled incidents as tracked in https://github.com/jiachengxu/akp-demo/issues/48 and incident https://256xgtfvocrdl6hd.cd.portal-server.akuity-platform/applications/argocd/guestbook-prod-oom?akuity-chat=6bzuatbvlk2jjpw4